### PR TITLE
Prevent crash when Quad::arclen() returns 0

### DIFF
--- a/fontcrunch/quadopt.cc
+++ b/fontcrunch/quadopt.cc
@@ -272,7 +272,9 @@ private:
 // of angle mismatch
 double measureQuad(const Thetas& curve, double s0, double s1, const Quad& q) {
 	ArclenFunctor derivs(q);
-	double ss = (s1 - s0) / q.arclen();
+	double ss = 0;
+	if (q.arclen() != 0)
+		ss = (s1 - s0) / q.arclen();
 	MeasureFunctor err(curve, s0, ss, derivs, q);
 	const int n = 10;
 	double dt = 1./n;


### PR DESCRIPTION
If Quad::arclen() is 0 then we end up dividing by zero which eventually
causes a crash in MeasureFunctor(). Not sure if this is a proper fix,
but it prevents the crash and the optimised glyph looks fine.

Fixes #6
